### PR TITLE
Prism tools fix

### DIFF
--- a/app/Ai/Prism/Agents/GuidelineRecommenderAgent.php
+++ b/app/Ai/Prism/Agents/GuidelineRecommenderAgent.php
@@ -22,12 +22,12 @@ class GuidelineRecommenderAgent extends PendingTextRequest
             model: config('cornell_ai.profiles')[ChatProfile::Chat->value]['model'],
         );
 
-        $this->withTools(array_filter([
+        $this->withTools(array_values(array_filter([
             new FetchGuidelinesTool(),
             new FetchGuidelinesListTool(),
             $scope->pageHasBeenRetrieved() ? new FetchScopePageContentTool() : null,
             new ScratchPadTool(),
-        ]))->withMaxSteps(10);
+        ])))->withMaxSteps(10);
 
         $this->usingTemperature(0.2);
 

--- a/app/Ai/Prism/Agents/GuidelineRecommenderAgent.php
+++ b/app/Ai/Prism/Agents/GuidelineRecommenderAgent.php
@@ -24,7 +24,6 @@ class GuidelineRecommenderAgent extends PendingTextRequest
 
         $this->withTools(array_values(array_filter([
             new FetchGuidelinesTool(),
-            new FetchGuidelinesListTool(),
             $scope->pageHasBeenRetrieved() ? new FetchScopePageContentTool() : null,
             new ScratchPadTool(),
         ])))->withMaxSteps(10);
@@ -47,7 +46,7 @@ class GuidelineRecommenderAgent extends PendingTextRequest
         $guidelinesListTool = new FetchGuidelinesListTool();
 
         return view('ai-agents.GuidelineRecommender.instructions', [
-            'guidelinesList' => json_encode($guidelinesListTool(), JSON_PRETTY_PRINT),
+            'guidelinesList' => $guidelinesListTool(),
             'scopeContext' => GuidelinesAnalyzerService::getScopeContext($this->scope),
         ])->render();
     }

--- a/app/Ai/Prism/Agents/ScopeAnalyzerAgent.php
+++ b/app/Ai/Prism/Agents/ScopeAnalyzerAgent.php
@@ -24,7 +24,6 @@ class ScopeAnalyzerAgent extends PendingRequest
 
         $this->withTools(array_values(array_filter([
             new FetchGuidelinesTool(),
-            new FetchGuidelinesListTool(),
             $scope->pageHasBeenRetrieved() ? new FetchScopePageContentTool() : null,
             new ScratchPadTool(),
         ])))->withMaxSteps(10);

--- a/app/Ai/Prism/Agents/ScopeAnalyzerAgent.php
+++ b/app/Ai/Prism/Agents/ScopeAnalyzerAgent.php
@@ -22,12 +22,12 @@ class ScopeAnalyzerAgent extends PendingRequest
             model: config('cornell_ai.profiles')[ChatProfile::Chat->value]['model'],
         );
 
-        $this->withTools(array_filter([
+        $this->withTools(array_values(array_filter([
             new FetchGuidelinesTool(),
             new FetchGuidelinesListTool(),
             $scope->pageHasBeenRetrieved() ? new FetchScopePageContentTool() : null,
             new ScratchPadTool(),
-        ]))->withMaxSteps(10);
+        ])))->withMaxSteps(10);
 
         $this->usingTemperature(0.2);
 


### PR DESCRIPTION
Prism tools must be strictly a value array. Array filtering was creating an indexed array and causing an openai error.

Also removed extraneous FetchGuidelinesListTool