### PR TITLE
Bugfix: ShowDocument does not expose unauthorized property

### DIFF
--- a/app/Livewire/Documents/ShowDocument.php
+++ b/app/Livewire/Documents/ShowDocument.php
@@ -4,17 +4,18 @@ namespace App\Livewire\Documents;
 
 use App\Livewire\Forms\DocumentForm;
 use App\Models\Document;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 class ShowDocument extends Component
 {
+    #[Locked]
     public string $slug;
     public Document $document;
     public DocumentForm $form;
-    public bool $showTitle = false;
 
-    public function mount()
+    public function mount(): void
     {
         $this->getDocument();
     }
@@ -27,7 +28,7 @@ class ShowDocument extends Component
         $this->form->setModel($this->document);
     }
 
-    public function save()
+    public function save(): void
     {
         $this->authorize('update', $this->form->document);
 

--- a/tests/Feature/Livewire/ShowDocumentTest.php
+++ b/tests/Feature/Livewire/ShowDocumentTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Enums\Roles;
+use App\Livewire\Documents\ShowDocument;
+use App\Models\Document;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Feature\FeatureTestCase;
+
+class ShowDocumentTest extends FeatureTestCase
+{
+    private string $slug;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->slug = 'test-doc-' . uniqid();
+    }
+
+    private function createDocument(): void
+    {
+        Document::create(['slug' => $this->slug, 'title' => 'Welcome', 'content' => 'Hello', 'is_current' => true, 'version' => 1]);
+    }
+
+    #[Test] public function renders_successfully_for_guest()
+    {
+        $this->createDocument();
+
+        Livewire::test(ShowDocument::class, ['slug' => $this->slug])
+            ->assertStatus(200)
+            ->assertSeeText('Welcome');
+    }
+
+    #[Test] public function slug_is_locked_and_cannot_be_set_by_client()
+    {
+        $this->createDocument();
+
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(ShowDocument::class, ['slug' => $this->slug])
+            ->set('slug', ['malicious' => 'array']);
+    }
+
+    #[Test] public function unauthenticated_user_cannot_save()
+    {
+        $this->createDocument();
+
+        Livewire::test(ShowDocument::class, ['slug' => $this->slug])
+            ->set('form.title', 'Hacked')
+            ->call('save')
+            ->assertForbidden();
+    }
+
+    #[Test] public function authenticated_admin_can_save()
+    {
+        $this->getLoggedInTestUser([Roles::SiteAdmin]);
+        $this->createDocument();
+
+        Livewire::test(ShowDocument::class, ['slug' => $this->slug])
+            ->set('form.title', 'Updated Title')
+            ->set('form.content', 'New content')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('documents', ['slug' => $this->slug, 'title' => 'Updated Title']);
+    }
+}


### PR DESCRIPTION
Nightwatch [issue 14](https://nightwatch.laravel.com/us/environments/9f83fa58-5d94-4a18-8fa1-30e68ee92da8/issues/14)

The ShowDocuments page was exposing a Laravel property that should not be settable, resulting in 
```
Cannot assign array to property App\Livewire\Documents\ShowDocument::$slug of type string
```

Fixed by locking the Livewire property.