### PR TITLE
Fix log in with email alias

### DIFF
--- a/app/Listeners/CUAuthorize.php
+++ b/app/Listeners/CUAuthorize.php
@@ -20,14 +20,18 @@ class CUAuthorize
         $remoteIdentity ??= $this->identityManager->getIdentity();
 
         // Look for a matching user.
-        $user = User::firstWhere('email', $remoteIdentity->email());
+        $user = User::whereIn('email', array_filter([
+            $remoteIdentity->primaryEmail(),
+            // This allows to log in with an old emailAlias email if someone has an account with that
+            $remoteIdentity->emailAlias() ?: null,
+        ]))->first();
 
         if (empty($user)) {
             // User does not exist, so create them.
             $user = new User;
             $user->name = $remoteIdentity->name() ?: $remoteIdentity->id();
-            $user->email = $remoteIdentity->email();
-            $user->uid = $remoteIdentity->uid;
+            $user->email = $remoteIdentity->primaryEmail();
+            $user->uid = $remoteIdentity->id();
             $user->password = Str::random(32);
             $user->save();
             Log::info("CUAuthorize: Created user $user->email with ID $user->id.");

--- a/composer.lock
+++ b/composer.lock
@@ -297,18 +297,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/CornellCustomDev/CD-LaravelCUAuth.git",
-                "reference": "ee85a6ddb6bcad92ec1c2012ced096a296172dd2"
+                "reference": "4b6776a12ddb7340d26d738d5741d59a22c9d11f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CornellCustomDev/CD-LaravelCUAuth/zipball/ee85a6ddb6bcad92ec1c2012ced096a296172dd2",
-                "reference": "ee85a6ddb6bcad92ec1c2012ced096a296172dd2",
+                "url": "https://api.github.com/repos/CornellCustomDev/CD-LaravelCUAuth/zipball/4b6776a12ddb7340d26d738d5741d59a22c9d11f",
+                "reference": "4b6776a12ddb7340d26d738d5741d59a22c9d11f",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "illuminate/support": "^12.0|^13.0",
-                "onelogin/php-saml": "^4.3.1",
+                "onelogin/php-saml": "^4.3.2",
                 "php": "^8.3"
             },
             "require-dev": {
@@ -338,7 +338,7 @@
                 "issues": "https://github.com/CornellCustomDev/CD-LaravelCUAuth/issues",
                 "source": "https://github.com/CornellCustomDev/CD-LaravelCUAuth/tree/livewire-auth"
             },
-            "time": "2026-05-20T23:14:31+00:00"
+            "time": "2026-06-01T17:55:27+00:00"
         },
         {
             "name": "cornell-custom-dev/laravel-ldap",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -304,18 +304,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/CornellCustomDev/CD-LaravelCUAuth.git",
-                "reference": "ee85a6ddb6bcad92ec1c2012ced096a296172dd2"
+                "reference": "4b6776a12ddb7340d26d738d5741d59a22c9d11f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CornellCustomDev/CD-LaravelCUAuth/zipball/ee85a6ddb6bcad92ec1c2012ced096a296172dd2",
-                "reference": "ee85a6ddb6bcad92ec1c2012ced096a296172dd2",
+                "url": "https://api.github.com/repos/CornellCustomDev/CD-LaravelCUAuth/zipball/4b6776a12ddb7340d26d738d5741d59a22c9d11f",
+                "reference": "4b6776a12ddb7340d26d738d5741d59a22c9d11f",
                 "shasum": ""
             },
             "require": {
                 "ext-openssl": "*",
                 "illuminate/support": "^12.0|^13.0",
-                "onelogin/php-saml": "^4.3.1",
+                "onelogin/php-saml": "^4.3.2",
                 "php": "^8.3"
             },
             "require-dev": {
@@ -323,7 +323,7 @@
                 "orchestra/testbench": "^10.0|^11.0",
                 "phpunit/phpunit": "^11.5|^12.5"
             },
-            "time": "2026-05-20T23:14:31+00:00",
+            "time": "2026-06-01T17:55:27+00:00",
             "type": "library",
             "extra": {
                 "laravel": {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -55,7 +55,7 @@
         'cornell-custom-dev/laravel-cu-auth' => array(
             'pretty_version' => 'dev-livewire-auth',
             'version' => 'dev-livewire-auth',
-            'reference' => 'ee85a6ddb6bcad92ec1c2012ced096a296172dd2',
+            'reference' => '4b6776a12ddb7340d26d738d5741d59a22c9d11f',
             'type' => 'library',
             'install_path' => __DIR__ . '/../cornell-custom-dev/laravel-cu-auth',
             'aliases' => array(),

--- a/vendor/cornell-custom-dev/laravel-cu-auth/composer.json
+++ b/vendor/cornell-custom-dev/laravel-cu-auth/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.3",
         "ext-openssl": "*",
         "illuminate/support": "^12.0|^13.0",
-        "onelogin/php-saml": "^4.3.1"
+        "onelogin/php-saml": "^4.3.2"
     },
     "require-dev": {
         "laravel/pint": "^1.20",
@@ -31,12 +31,7 @@
         ],
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
-        "test": "@php vendor/bin/phpunit -c ./ --color",
-        "sync": "@php bin/sync",
-        "ci": [
-            "@post-autoload-dump",
-            "@test"
-        ]
+        "test": "@php vendor/bin/phpunit -c ./ --color"
     },
     "config": {
         "sort-packages": true

--- a/vendor/cornell-custom-dev/laravel-cu-auth/src/DataObjects/RemoteIdentity.php
+++ b/vendor/cornell-custom-dev/laravel-cu-auth/src/DataObjects/RemoteIdentity.php
@@ -28,12 +28,10 @@ readonly class RemoteIdentity
         return new RemoteIdentity(
             idp: $idp,
             uid: $uid,
-            principalName: $eduPersonPrincipalName
-                ?? trim($mail ?? ''),
+            principalName: trim($eduPersonPrincipalName ?? ''),
             displayName: $displayName
                 ?? $cn
                 ?? trim(($givenName ?? '').' '.($sn ?? '')),
-            email: trim($mail ?? ''),
             mail: trim($mail ?? ''),
             data: $data,
         );
@@ -61,20 +59,29 @@ readonly class RemoteIdentity
         };
     }
 
-    /*
-     * Returns the eduPersonPrincipalName
-     */
     public function principalName(): string
     {
         return $this->principalName;
     }
 
+    public function primaryEmail(): string
+    {
+        return $this->principalName;
+    }
+
+    public function emailAlias(): string
+    {
+        return $this->mail;
+    }
+
     /**
      * Returns the primary email (netid@cornell.edu|cwid@med.cornell.edu) if available, otherwise the alias email.
+     *
+     * @deprecated Use of email() should be replaced with primaryEmai() or emailAlias(), as appropriate.
      */
     public function email(): string
     {
-        return $this->principalName ?: $this->mail;
+        return $this->primaryEmail() ?: $this->emailAlias();
     }
 
     /**

--- a/vendor/cornell-custom-dev/laravel-cu-auth/src/Listeners/AuthorizeUser.php
+++ b/vendor/cornell-custom-dev/laravel-cu-auth/src/Listeners/AuthorizeUser.php
@@ -20,13 +20,13 @@ class AuthorizeUser
 
         // Look for a matching user.
         $userModel = config('auth.providers.users.model');
-        $user = $userModel::firstWhere('email', $remoteIdentity->email());
+        $user = $userModel::firstWhere('email', $remoteIdentity->primaryEmail() ?: $remoteIdentity->emailAlias());
 
         if (empty($user)) {
             // User does not exist, so create them.
             $user = new $userModel;
             $user->name = $remoteIdentity->name();
-            $user->email = $remoteIdentity->email();
+            $user->email = $remoteIdentity->primaryEmail() ?: $remoteIdentity->emailAlias();
             $user->password = Str::random(32);
             $user->save();
             Log::info("AuthorizeUser: Created user $user->email with ID $user->id.");


### PR DESCRIPTION
Changes to CU Auth RemoteIdentity broke the CUAuthorize listener. This fixes by allowing a login with the emailAlias if that user exists first.